### PR TITLE
Show the video clean — drop global dark tint

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -242,16 +242,9 @@
       transition: transform 900ms cubic-bezier(0.65, 0, 0.35, 1);
       image-rendering: auto;
     }
-    .bg-video__tint {
-      position: fixed; inset: 0;
-      z-index: -1;
-      background: linear-gradient(180deg, rgba(10,10,10,0.35) 0%, rgba(10,10,10,0.55) 100%);
-      pointer-events: none;
-      transition: opacity 400ms var(--ease);
-    }
-    /* When video collapses to side, dim the global tint so it doesn't darken
-       the area where content now sits in the open. */
-    body.video-collapsed .bg-video__tint { opacity: 0; }
+    /* Global tint removed — the video plays clean. Section backgrounds and
+       hero text-shadow handle legibility where needed. */
+    .bg-video__tint { display: none; }
 
     /* Content gets right padding when video docks to the right (desktop only) */
     @media (min-width: 1024px) {
@@ -288,7 +281,7 @@
       text-align: center;
       margin: 0;
       max-width: 1200px;
-      text-shadow: 0 2px 24px rgba(0,0,0,0.4);
+      text-shadow: 0 2px 32px rgba(0,0,0,0.6), 0 0 80px rgba(0,0,0,0.35);
       z-index: 5;
       pointer-events: none;
       will-change: opacity;


### PR DESCRIPTION
Remove o gradient escuro fixo (`.bg-video__tint`) que ficava acima do vídeo. A hero passa a mostrar o vídeo 4K limpo. Hero "Portfólio" recebe text-shadow mais forte (duas camadas) pra continuar legível sobre qualquer frame.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjAyCfWLPkhr25AjWsXwQa)_