### PR TITLE
Hero shows video only — drop Portfolio text overlay

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -755,9 +755,7 @@
   <main id="main">
 
     <!-- HERO -->
-    <section class="hero" id="hero" aria-label="Portfólio">
-      <h1 class="hero__slogan">Portfólio</h1>
-    </section>
+    <section class="hero" id="hero" aria-label="Portfólio"></section>
 
     <!-- SPACER: scroll-driven zoom into the house, video plays uninterrupted -->
     <div class="video-spacer" aria-hidden="true"></div>


### PR DESCRIPTION
Remove o h1 "Portfólio" da hero. O usuário agora vê apenas o vídeo limpo na primeira tela. JS já tinha guard contra heroSlogan nulo então não quebra a coreografia de scroll.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjAyCfWLPkhr25AjWsXwQa)_